### PR TITLE
feat: Configure custom MariaDB with separate databases for Moodle and…

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,61 @@
+version: "3.8"
+
+services:
+  moodle:
+    image: bitnami/moodle:4.5.0
+    container_name: moodle
+    environment:
+      - ALLOW_EMPTY_PASSWORD=no
+      - MARIADB_HOST=mysql
+      - MARIADB_PORT_NUMBER=3306
+      - MARIADB_ROOT_PASSWORD=cc5308
+      - MOODLE_DATABASE_NAME=moodle_db
+      - MOODLE_DATABASE_USER=root
+      - MOODLE_DATABASE_PASSWORD=cc5308
+      - MOODLE_USERNAME=admin
+      - MOODLE_PASSWORD=admin123
+      - MOODLE_SKIP_INSTALL=no
+    depends_on:
+      - mysql
+    ports:
+      - "8081:8080"
+    networks:
+      - tarea3
+    restart: unless-stopped
+
+  wordpress:
+    image: wordpress:latest
+    container_name: wordpress
+    environment:
+      - WORDPRESS_DB_HOST=mysql
+      - WORDPRESS_DB_USER=wp_user
+      - WORDPRESS_DB_PASSWORD=wp_pass
+      - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      - mysql
+    ports:
+      - "8080:80"
+    networks:
+      - tarea3
+    restart: unless-stopped
+
+  mysql:
+    build: ./mariadb
+    container_name: mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=cc5308
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=wp_user
+      - MYSQL_PASSWORD=wp_pass
+    volumes:
+      - mariadb_data:/var/lib/mysql
+    networks:
+      - tarea3
+    restart: unless-stopped
+
+networks:
+  tarea3:
+    driver: bridge
+
+volumes:
+  mariadb_data:

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,0 +1,4 @@
+FROM mariadb:latest
+
+# Initialization script
+COPY init-databases.sql /docker-entrypoint-initdb.d/

--- a/mariadb/init-databases.sql
+++ b/mariadb/init-databases.sql
@@ -1,0 +1,12 @@
+-- Create databases for Moodle and WordPress
+CREATE DATABASE IF NOT EXISTS moodle_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE DATABASE IF NOT EXISTS wordpress CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- Create user for wordpress
+CREATE USER IF NOT EXISTS 'wp_user'@'%' IDENTIFIED BY 'wp_pass';
+GRANT ALL PRIVILEGES ON wordpress.* TO 'wp_user'@'%';
+
+-- Root user privileges for Moodle
+GRANT ALL PRIVILEGES ON moodle_db.* TO 'root'@'%';
+
+FLUSH PRIVILEGES;


### PR DESCRIPTION
… WordPress

- Add custom Dockerfile and init script for MariaDB
- Create dedicated databases: moodle_db and wordpress
- Configure proper user permissions and credentials
- Update compose.yml to use custom MariaDB build